### PR TITLE
feat: add chatgpt style frontend

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,181 +1,108 @@
-.app {
+.chatgpt-app {
   display: flex;
   height: 100vh;
+  background: #343541;
+  color: #ececf1;
 }
 
-/* Sidebar */
 .sidebar {
-  width: 240px;
-  background: #1e1f24;
-  color: #fff;
+  width: 260px;
+  background: #202123;
   display: flex;
   flex-direction: column;
-  padding-top: 1rem;
-}
-
-.logo {
-  font-size: 1.5rem;
-  font-weight: 600;
-  padding: 0 1rem 1rem 1rem;
-}
-
-.nav a {
-  display: block;
-  padding: 0.75rem 1rem;
-  margin: 0 0.5rem;
-  border-radius: 8px;
-  color: #bdbdbd;
-  text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.nav a:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
-}
-
-.sidebar-footer {
-  margin-top: auto;
   padding: 1rem;
+  box-sizing: border-box;
 }
 
-.upgrade {
-  width: 100%;
-  background: #2e8bff;
-  color: #fff;
+.new-chat {
+  background: #10a37f;
   border: none;
-  padding: 0.5rem 0;
-  border-radius: 8px;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
   cursor: pointer;
 }
 
-/* Main area */
-.main {
+.history {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  flex: 1;
+  overflow: auto;
+}
+
+.history li {
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.history li:hover {
+  background: #2a2b32;
+}
+
+.chat {
   flex: 1;
   display: flex;
   flex-direction: column;
-  background: #f5f5f5;
-  color: #1a1a1a;
 }
 
-.topbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.messages {
+  flex: 1;
+  overflow: auto;
   padding: 1rem;
-  border-bottom: 1px solid #e5e5e5;
-  background: #fff;
 }
 
-.search-wrapper input {
-  width: 260px;
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 20px;
-  background: #f0f0f0;
-}
-
-.topbar-actions {
+.message {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
+  padding: 1rem 0;
 }
 
-.mode-toggle {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 1.2rem;
+.message.user {
+  background: #343541;
+}
+
+.message.assistant {
+  background: #444654;
 }
 
 .avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  background: #666;
-  color: #fff;
+  border-radius: 4px;
+  background: #272833;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 500;
+  font-weight: bold;
 }
 
 .content {
-  padding: 2rem;
-  overflow: auto;
+  max-width: 700px;
+  white-space: pre-wrap;
 }
 
-.cards {
+.input {
   display: flex;
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
-
-.card {
-  flex: 1;
-  padding: 1.25rem;
-  border-radius: 12px;
-  font-size: 0.9rem;
-  line-height: 1.3;
-}
-
-.card h3 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
-}
-
-.card.examples {
-  background: #ffe96a;
-}
-
-.card.capabilities {
-  background: #78fb6d;
-}
-
-.card.limitations {
-  background: #ff78f7;
-}
-
-.input-bar {
-  margin-top: auto;
   padding: 1rem;
-  border-top: 1px solid #e5e5e5;
-  background: #fff;
+  border-top: 1px solid #565869;
 }
 
-.input-bar input {
-  width: 100%;
+.input input {
+  flex: 1;
+  border: none;
+  background: #40414f;
+  color: #ececf1;
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
+.input button {
+  margin-left: 0.5rem;
+  background: #10a37f;
+  color: #fff;
+  border: none;
   padding: 0.75rem 1rem;
-  border-radius: 20px;
-  border: 1px solid #ccc;
-  font-size: 0.9rem;
+  border-radius: 4px;
 }
-
-/* Dark mode tweaks */
-.app.dark .main {
-  background: #1e1e1e;
-  color: #f5f5f5;
-}
-
-.app.dark .topbar {
-  background: #2b2b2b;
-  border-bottom-color: #333;
-}
-
-.app.dark .search-wrapper input {
-  background: #3a3a3a;
-  color: #fff;
-}
-
-.app.dark .input-bar {
-  background: #2b2b2b;
-  border-top-color: #333;
-}
-
-.app.dark .input-bar input {
-  background: #3a3a3a;
-  border-color: #555;
-  color: #fff;
-}
-

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,67 +2,46 @@ import { useState } from 'react'
 import './App.css'
 
 function App() {
-  const [darkMode, setDarkMode] = useState(false)
+  const [messages, setMessages] = useState([
+    { role: 'assistant', content: "Hello! I'm a ChatGPT clone. How can I help?" },
+  ])
+  const [input, setInput] = useState('')
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (!input.trim()) return
+    setMessages([...messages, { role: 'user', content: input }])
+    setInput('')
+  }
 
   return (
-    <div className={`app ${darkMode ? 'dark' : 'light'}`}>
+    <div className="chatgpt-app">
       <aside className="sidebar">
-        <div className="logo">F2AI</div>
-        <nav className="nav">
-          <a href="#">All Chat</a>
-          <a href="#">AI Image Generate</a>
-          <a href="#">Manage Account</a>
-          <a href="#">Help Centre</a>
-        </nav>
-        <div className="sidebar-footer">
-          <button className="upgrade">Upgrade</button>
-        </div>
+        <button className="new-chat">+ New chat</button>
+        <ul className="history">
+          <li>Chat with Clone</li>
+        </ul>
       </aside>
-
-      <section className="main">
-        <header className="topbar">
-          <div className="search-wrapper">
-            <input type="text" placeholder="Search AI Tools" />
-          </div>
-          <div className="topbar-actions">
-            <button
-              className="mode-toggle"
-              onClick={() => setDarkMode(!darkMode)}
-              aria-label="Toggle theme"
-            >
-              {darkMode ? '☀️' : '🌙'}
-            </button>
-            <div className="avatar">N</div>
-          </div>
-        </header>
-
-        <div className="content">
-          <h2>Hello Neel</h2>
-          <div className="cards">
-            <div className="card examples">
-              <h3>Examples</h3>
-              <p>&quot;What would happen if all clocks suddenly stopped?&quot;</p>
+      <main className="chat">
+        <div className="messages">
+          {messages.map((m, i) => (
+            <div key={i} className={`message ${m.role}`}>
+              <div className="avatar">{m.role === 'user' ? 'U' : 'G'}</div>
+              <div className="content">{m.content}</div>
             </div>
-            <div className="card capabilities">
-              <h3>Capabilities</h3>
-              <p>Create a plot twist for a classic tale</p>
-            </div>
-            <div className="card limitations">
-              <h3>Limitations</h3>
-              <p>Make it based on facts I haven’t verified yet</p>
-            </div>
-          </div>
+          ))}
         </div>
-
-        <form className="input-bar">
+        <form className="input" onSubmit={handleSubmit}>
           <input
-            type="text"
-            placeholder="Can you explain more information about Atson agency PVT"/>
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Send a message..."
+          />
+          <button type="submit">Send</button>
         </form>
-      </section>
+      </main>
     </div>
   )
 }
 
 export default App
-


### PR DESCRIPTION
## Summary
- replace app with ChatGPT-style chat interface
- add simple message state and input handling
- style layout to mimic ChatGPT appearance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2f02701248321b94581478d2007f3