### PR TITLE
feat: add chatgpt-style interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
     <title>F2AI</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -1,108 +1,206 @@
-.chatgpt-app {
-  display: flex;
-  height: 100vh;
-  background: #343541;
-  color: #ececf1;
+:root {
+  --sidebar-width: 260px;
+  --sidebar-bg: #202123;
+  --sidebar-text: #ececf1;
+  --sidebar-hover: #2a2b32;
+
+  --main-bg: #f7f7f8;
+  --message-bg-user: #ececec;
+  --message-bg-assistant: #ffffff;
+
+  --border-color: #d1d5db;
+  --radius: 6px;
+  --font-base: 'Inter', sans-serif;
 }
 
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-base);
+  height: 100%;
+}
+
+.app {
+  display: flex;
+  height: 100vh;
+  background: var(--main-bg);
+}
+
+/* Sidebar */
 .sidebar {
-  width: 260px;
-  background: #202123;
+  width: var(--sidebar-width);
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
   display: flex;
   flex-direction: column;
-  padding: 1rem;
-  box-sizing: border-box;
+}
+
+.sidebar-header {
+  padding: 12px;
+  border-bottom: 1px solid #2f303a;
 }
 
 .new-chat {
-  background: #10a37f;
-  border: none;
-  color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #4a4b54;
+  background: transparent;
+  color: inherit;
+  border-radius: var(--radius);
+  font-weight: 500;
   cursor: pointer;
 }
-
-.history {
-  list-style: none;
-  padding: 0;
-  margin: 1rem 0;
-  flex: 1;
-  overflow: auto;
+.new-chat i {
+  margin-right: 8px;
+}
+.new-chat:hover {
+  background: var(--sidebar-hover);
 }
 
-.history li {
-  padding: 0.5rem;
-  border-radius: 4px;
+.chat-history {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.history-item {
+  padding: 8px 12px;
+  border-radius: var(--radius);
   cursor: pointer;
 }
-
-.history li:hover {
-  background: #2a2b32;
+.history-item:hover {
+  background: var(--sidebar-hover);
 }
-
-.chat {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.messages {
-  flex: 1;
-  overflow: auto;
-  padding: 1rem;
-}
-
-.message {
-  display: flex;
-  gap: 1rem;
-  padding: 1rem 0;
-}
-
-.message.user {
+.history-item.active {
   background: #343541;
 }
 
-.message.assistant {
-  background: #444654;
+.sidebar-footer {
+  padding: 8px 12px;
+  border-top: 1px solid #2f303a;
 }
 
-.avatar {
+.footer-btn {
+  display: block;
+  width: 100%;
+  padding: 8px 0;
+  background: none;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.footer-btn i {
+  margin-right: 10px;
+}
+.footer-btn:hover {
+  background: var(--sidebar-hover);
+}
+
+/* Main area */
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--main-bg);
+}
+
+.top-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 50px;
+  border-bottom: 1px solid var(--border-color);
+  position: relative;
+}
+.title {
+  font-weight: 600;
+}
+.top-bar-actions {
+  position: absolute;
+  right: 15px;
+  display: flex;
+  gap: 15px;
+  color: #6b7280;
+}
+
+/* Chat window */
+.chat-window {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+/* Messages */
+.message {
+  display: flex;
+  margin-bottom: 18px;
+}
+.message .avatar {
   width: 32px;
   height: 32px;
-  border-radius: 4px;
-  background: #272833;
+  border-radius: 50%;
+  background: #10a37f;
+  color: #fff;
   display: flex;
-  align-items: center;
   justify-content: center;
-  font-weight: bold;
+  align-items: center;
+  font-size: 14px;
+  margin-right: 12px;
+}
+.message.user .avatar {
+  background: #8e8ea0;
+}
+.message .bubble {
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  max-width: 80%;
+  line-height: 1.4;
+}
+.message.user .bubble {
+  background: var(--message-bg-user);
+  align-self: flex-end;
+}
+.message.assistant .bubble {
+  background: var(--message-bg-assistant);
+  border: 1px solid var(--border-color);
 }
 
-.content {
-  max-width: 700px;
-  white-space: pre-wrap;
-}
-
-.input {
+/* Composer */
+.composer {
   display: flex;
-  padding: 1rem;
-  border-top: 1px solid #565869;
+  align-items: flex-end;
+  padding: 16px;
+  border-top: 1px solid var(--border-color);
+  background: var(--main-bg);
 }
 
-.input input {
+#prompt {
   flex: 1;
-  border: none;
-  background: #40414f;
-  color: #ececf1;
-  padding: 0.75rem;
-  border-radius: 4px;
+  resize: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 10px;
+  font-family: inherit;
+  background: #fff;
+  line-height: 1.4;
 }
 
-.input button {
-  margin-left: 0.5rem;
+#send-btn {
   background: #10a37f;
   color: #fff;
   border: none;
-  padding: 0.75rem 1rem;
-  border-radius: 4px;
+  padding: 10px 14px;
+  margin-left: 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 }
+#send-btn:hover {
+  background: #0e8b6a;
+}
+#send-btn i {
+  font-size: 16px;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,47 +1,96 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import './App.css'
 
 function App() {
   const [messages, setMessages] = useState([
-    { role: 'assistant', content: "Hello! I'm a ChatGPT clone. How can I help?" },
+    { role: 'assistant', content: 'Hello! How can I help you today?' },
   ])
   const [input, setInput] = useState('')
+  const chatWindowRef = useRef(null)
 
-  const handleSubmit = (e) => {
-    e.preventDefault()
-    if (!input.trim()) return
-    setMessages([...messages, { role: 'user', content: input }])
+  useEffect(() => {
+    const el = chatWindowRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages])
+
+  const sendMessage = () => {
+    const text = input.trim()
+    if (!text) return
+    setMessages((prev) => [...prev, { role: 'user', content: text }])
     setInput('')
+
+    setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: 'This is a placeholder response.' },
+      ])
+    }, 500)
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
   }
 
   return (
-    <div className="chatgpt-app">
+    <div className="app">
       <aside className="sidebar">
-        <button className="new-chat">+ New chat</button>
-        <ul className="history">
-          <li>Chat with Clone</li>
-        </ul>
+        <div className="sidebar-header">
+          <button className="new-chat">
+            <i className="fa fa-plus"></i> New Chat
+          </button>
+        </div>
+        <nav className="chat-history">
+          <div className="history-item active">Sample conversation</div>
+          <div className="history-item">Another chat</div>
+        </nav>
+        <div className="sidebar-footer">
+          <button className="footer-btn">
+            <i className="fa fa-gear"></i> Settings
+          </button>
+          <button className="footer-btn">
+            <i className="fa fa-right-from-bracket"></i> Log out
+          </button>
+        </div>
       </aside>
-      <main className="chat">
-        <div className="messages">
+
+      <main className="main">
+        <header className="top-bar">
+          <div className="title">ChatGPT</div>
+          <div className="top-bar-actions">
+            <i className="fa fa-lightbulb"></i>
+            <i className="fa fa-user"></i>
+          </div>
+        </header>
+        <section className="chat-window" ref={chatWindowRef}>
           {messages.map((m, i) => (
             <div key={i} className={`message ${m.role}`}>
-              <div className="avatar">{m.role === 'user' ? 'U' : 'G'}</div>
-              <div className="content">{m.content}</div>
+              <div className="avatar">
+                {m.role === 'assistant' ? 'GPT' : 'U'}
+              </div>
+              <div className="bubble">{m.content}</div>
             </div>
           ))}
-        </div>
-        <form className="input" onSubmit={handleSubmit}>
-          <input
+        </section>
+        <footer className="composer">
+          <textarea
+            id="prompt"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Send a message..."
-          />
-          <button type="submit">Send</button>
-        </form>
+            rows={1}
+          ></textarea>
+          <button id="send-btn" onClick={sendMessage}>
+            <i className="fa fa-paper-plane"></i>
+          </button>
+        </footer>
       </main>
     </div>
   )
 }
 
 export default App
+


### PR DESCRIPTION
## Summary
- replace demo layout with ChatGPT-style sidebar, header, chat window, and composer
- add icons via Font Awesome
- provide placeholder message handling and auto-scroll in React

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f1d8d8608321ba9baf0b7f99b771